### PR TITLE
Add SoreLoserUpperHalfPlayer class and update Program.cs to test

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -57,8 +57,21 @@ Console.WriteLine("-------------------");
 
 // HumanPlayer (prompts user input)
 Player human = new HumanPlayer() { Name = "You" };
-Console.WriteLine("Human player will now roll against Bigun Rollsalot:");
+Console.WriteLine("👤 Human player will now roll against Bigun Rollsalot:");
 human.Play(large);
+
+Console.WriteLine("-------------------");
+
+// SoreLoserUpperHalfPlayer
+Player soreHalf = new SoreLoserUpperHalfPlayer() { Name = "HalfMad Hank" };
+try
+{
+    soreHalf.Play(player2);
+}
+catch (Exception ex)
+{
+    Console.WriteLine($"[!]  {soreHalf.Name} had a meltdown: {ex.Message}");
+}
 
 Console.WriteLine("-------------------");
 
@@ -74,7 +87,8 @@ List<Player> players = new List<Player>()
     oneHigher,
     upper,
     sore,
-    human
+    human,
+    soreHalf
 };
 
 PlayMany(players);

--- a/SoreLoserUpperHalfPlayer.cs
+++ b/SoreLoserUpperHalfPlayer.cs
@@ -1,9 +1,36 @@
 namespace ShootingDice;
-// TODO: Complete this class
 
-// A Player who always rolls in the upper half of their possible role and
-//  who throws an exception when they lose to the other player
-public class SoreLoserUpperHalfPlayer
+// A Player who always rolls in the upper half of their possible roll and
+// throws an exception when they lose
+public class SoreLoserUpperHalfPlayer : Player
 {
+    public override int Roll()
+    {
+        // Upper half starts at (DiceSize / 2) + 1, ends at DiceSize
+        int min = (DiceSize / 2) + 1;
+        return new Random().Next(min, DiceSize + 1);
+    }
 
+    public override void Play(Player other)
+    {
+        int myRoll = this.Roll();
+        int theirRoll = other.Roll();
+
+        Console.WriteLine($"{Name} rolls a {myRoll}");
+        Console.WriteLine($"{other.Name} rolls a {theirRoll}");
+
+        if (myRoll > theirRoll)
+        {
+            Console.WriteLine($"{Name} Wins!");
+        }
+        else if (myRoll < theirRoll)
+        {
+            // The sore loser moment
+            throw new Exception($"{Name} loses and throws a fit! 😡");
+        }
+        else
+        {
+            Console.WriteLine("It's a tie");
+        }
+    }
 }


### PR DESCRIPTION
### Add SoreLoserUpperHalfPlayer

- Implements `SoreLoserUpperHalfPlayer`, a subclass of `Player` that:
  - Always rolls in the upper half of its possible dice range
  - Throws an exception if it loses a match
- Updates `Program.cs`:
  - Adds an instance of `SoreLoserUpperHalfPlayer` to the simulation
  - Handles its exception gracefully
  - Includes the new player in `PlayMany()`

🎲 Final player type from the Shooting Dice exercise completed!
